### PR TITLE
Add a simple identity prop test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ exclude = [
 rand = "0.6"
 rand_core = "0.3"
 rand_xoshiro = "0.1"
+
+[dev-dependencies]
+proptest = "0.9.4"

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -14,6 +14,7 @@ enum UndecodedDegree {
     Many(usize),     // number of blocks that haven't yet been decoded
 }
 
+#[derive(Debug)]
 pub struct Decoder<'a> {
     pub num_blocks: usize,
     pub num_augmented_blocks: usize,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -50,7 +50,6 @@ impl<'a> Decoder {
     ) -> Option<Vec<u8>> {
         if self.num_undecoded_data_blocks == 0 {
             // Decoding has already finished and the decoded data has already been returned.
-            println!("Decoding has already finished and the decoded data has already been returned");
             return None;
         }
 
@@ -145,7 +144,6 @@ impl<'a> Decoder {
             Some(decoded_data)
         } else {
             // Decoding not yet complete.
-            println!("Decoding not yet complete");
             None
         }
     }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -137,10 +137,10 @@ impl<'a> Decoder<'a> {
             // Decoding finished -- return decoded data.
             let mut decoded_data = std::mem::replace(&mut self.augmented_data, Vec::new());
             decoded_data.truncate(self.block_size * self.num_blocks);
-            return Some(decoded_data);
+            Some(decoded_data)
         } else {
             // Decoding not yet complete.
-            return None;
+            None
         }
     }
 
@@ -153,7 +153,7 @@ impl<'a> Decoder<'a> {
                 return DecodeResult::Complete(decoded_data);
             }
         }
-        return DecodeResult::InProgress(self);
+        DecodeResult::InProgress(self)
     }
 
     pub fn get_incomplete_result(&self) -> (&[bool], &[u8]) {
@@ -242,7 +242,7 @@ fn undecoded_degree(adjacent_block_ids: &[BlockIndex], blocks_decoded: &[bool]) 
         }
     }
 
-    return degree;
+    degree
 }
 
 fn block_to_decode(adjacent_blocks: &[BlockIndex], block_decoded: &[bool]) -> Option<BlockIndex> {
@@ -257,6 +257,6 @@ fn block_to_decode(adjacent_blocks: &[BlockIndex], block_decoded: &[bool]) -> Op
         }
     }
 
-    return to_decode;
+    to_decode
 }
 

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -5,6 +5,7 @@ use crate::decode::Decoder;
 use crate::util::{sample_with_exclusive_repeats, xor_block, seed_block_rng, get_adjacent_blocks};
 use crate::types::{StreamId, BlockIndex, CheckBlockId};
 
+#[derive(Debug)]
 pub struct OnlineCoder {
     block_size: usize,
     epsilon: f64,

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -122,8 +122,8 @@ impl OnlineCoder {
 }
 
 impl<'a> Iterator for BlockIter<'a> {
-    type Item = Vec<u8>;
-    fn next(&mut self) -> Option<Vec<u8>> {
+    type Item = (CheckBlockId, Vec<u8>);
+    fn next(&mut self) -> Option<(CheckBlockId, Vec<u8>)> {
         let num_blocks = self.data.len() / self.block_size;
         let num_aux_blocks = self.aux_data.len() / self.block_size;
         let mut check_block = vec![0; self.block_size];
@@ -151,7 +151,7 @@ impl<'a> Iterator for BlockIter<'a> {
         }
 
         self.check_block_id += 1;
-        Some(check_block)
+        Some((self.check_block_id - 1, check_block))
     }
 }
 

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -12,6 +12,7 @@ pub struct OnlineCoder {
     q: usize,
 }
 
+#[derive(Debug)]
 pub struct BlockIter<'a> {
     pub data: &'a [u8],
     pub aux_data: Vec<u8>,

--- a/src/util.rs
+++ b/src/util.rs
@@ -42,5 +42,5 @@ pub fn sample_with_exclusive_repeats(
         }
     }
 
-    return selected.into_iter().collect();
+    selected.into_iter().collect()
 }

--- a/tests/basic.proptest-regressions
+++ b/tests/basic.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc d1db460bd8c4f898ccdd24f069136e875c86fb1d6630e1a09571bbf89d1f662b # shrinks to s = ""
+cc 0fd5fd9afb0824aa64dfdbabaacca4c4b39e2ab214fa492633b518123690f42a # shrinks to s = "AaA0 aA0 a\u{b}0a"

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,0 +1,54 @@
+extern crate online_codes;
+
+use online_codes::encode::online_coder::OnlineCoder;
+use rand::{thread_rng, Rng};
+use rand::distributions::Alphanumeric;
+
+#[test]
+fn basic_test() {
+
+    let total_len = 128;
+    let s: String = thread_rng().sample_iter(&Alphanumeric).take(total_len).collect();
+    let buf = s.clone().into_bytes();
+    let len = buf.len();
+    let to_compare = buf.clone();
+
+    let online_coder = OnlineCoder::new(8);
+    let encoded = online_coder.encode(&buf, 0);
+    let num_blocks = 16;
+    let mut decoder = online_coder.decode(num_blocks as usize, 0);
+
+    println!("total_len: {:?}", total_len);
+    println!("s: {:?}", s);
+    println!("buf: {:?}", buf);
+    println!("len: {:?}", len);
+    println!("online_coder: {:?}", online_coder);
+
+    let mut check_block_id = 0;
+    for check_block in encoded {
+
+        match check_block {
+            None => break,
+            Some(block) => {
+                match decoder.decode_block(check_block_id, &check_block) {
+                    None => break,
+                    Some(res) => {
+                        println!("res: {:?}", res);
+                    }
+                }
+                // println!("check_block_id: {:?}, check_block: {:?}", check_block_id, check_block);
+                if check_block_id == 10 {
+                    break
+                }
+                check_block_id += 1;
+
+            }
+        }
+
+    }
+
+
+    // println!("encoded: {:?}", encoded);
+    // println!("decoder: {:?}", decoder);
+    assert_eq!(1, 2);
+}

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,6 +1,7 @@
 extern crate online_codes;
 
 use online_codes::encode::OnlineCoder;
+use online_codes::decode::Decoder;
 use rand::{thread_rng, Rng};
 use rand::distributions::Alphanumeric;
 
@@ -13,33 +14,16 @@ fn basic_test() {
     let len = buf.len();
     let _to_compare = buf.clone();
 
-    let online_coder = OnlineCoder::new(8);
-    let encoded = online_coder.encode(&buf, 0);
+    let coder = OnlineCoder::new(8);
+    let encoded = coder.encode(&buf, 0);
     let num_blocks = 16;
-    let mut decoder = online_coder.decode(num_blocks as usize, 0);
+    let mut decoder = coder.decode(num_blocks as usize, 0);
 
-    println!("total_len: {:?}", total_len);
-    println!("s: {:?}", s);
-    println!("buf: {:?}", buf);
-    println!("len: {:?}", len);
-    println!("online_coder: {:?}", online_coder);
+    println!("coder: {:?}", coder);
+    println!();
+    println!("encoded: {:?}", encoded);
+    println!();
+    println!("decoder: {:?}", decoder);
 
-    let mut check_block_id = 0;
-    for check_block in encoded {
-        match decoder.decode_block(check_block_id, &check_block) {
-            None => break,
-            Some(res) => {
-                println!("res: {:?}", res);
-            }
-        }
-        // println!("check_block_id: {:?}, check_block: {:?}", check_block_id, check_block);
-        if check_block_id == 10 {
-            break
-        }
-        check_block_id += 1;
-    }
-
-    // println!("encoded: {:?}", encoded);
-    // println!("decoder: {:?}", decoder);
-    assert_eq!(1, 2);
+    assert_eq!(1, 1);
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,29 +1,30 @@
 extern crate online_codes;
 
 use online_codes::encode::OnlineCoder;
-use online_codes::decode::Decoder;
 use rand::{thread_rng, Rng};
 use rand::distributions::Alphanumeric;
 
 #[test]
 fn basic_test() {
 
-    let total_len = 128;
-    let s: String = thread_rng().sample_iter(&Alphanumeric).take(total_len).collect();
+    let buf_len = 128;
+    let s: String = thread_rng().sample_iter(&Alphanumeric).take(buf_len).collect();
     let buf = s.clone().into_bytes();
-    let len = buf.len();
-    let _to_compare = buf.clone();
 
-    let coder = OnlineCoder::new(8);
+    let block_size = 16;
+
+    let coder = OnlineCoder::new(block_size);
     let encoded = coder.encode(&buf, 0);
-    let num_blocks = 16;
+    let num_blocks = buf_len / block_size;
     let mut decoder = coder.decode(num_blocks as usize, 0);
 
-    println!("coder: {:?}", coder);
-    println!();
-    println!("encoded: {:?}", encoded);
-    println!();
-    println!("decoder: {:?}", decoder);
-
-    assert_eq!(1, 1);
+    for (block_id, block) in encoded {
+        match decoder.decode_block(block_id, &block) {
+            None => continue,
+            Some(res) => {
+                assert_eq!(buf, res);
+                break
+            }
+        }
+    }
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -8,15 +8,16 @@ use rand::distributions::Alphanumeric;
 fn basic_test() {
 
     let buf_len = 128;
+    let block_size = 16;
+    let check_block_id = 0;
+
     let s: String = thread_rng().sample_iter(&Alphanumeric).take(buf_len).collect();
     let buf = s.clone().into_bytes();
 
-    let block_size = 16;
-
     let coder = OnlineCoder::new(block_size);
-    let encoded = coder.encode(&buf, 0);
+    let encoded = coder.encode(&buf, check_block_id);
     let num_blocks = buf_len / block_size;
-    let mut decoder = coder.decode(num_blocks as usize, 0);
+    let mut decoder = coder.decode(num_blocks as usize, check_block_id);
 
     for (block_id, block) in encoded {
         match decoder.decode_block(block_id, &block) {

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -11,7 +11,7 @@ fn basic_test() {
     let s: String = thread_rng().sample_iter(&Alphanumeric).take(total_len).collect();
     let buf = s.clone().into_bytes();
     let len = buf.len();
-    let to_compare = buf.clone();
+    let _to_compare = buf.clone();
 
     let online_coder = OnlineCoder::new(8);
     let encoded = online_coder.encode(&buf, 0);
@@ -26,27 +26,18 @@ fn basic_test() {
 
     let mut check_block_id = 0;
     for check_block in encoded {
-
-        match check_block {
+        match decoder.decode_block(check_block_id, &check_block) {
             None => break,
-            Some(block) => {
-                match decoder.decode_block(check_block_id, &check_block) {
-                    None => break,
-                    Some(res) => {
-                        println!("res: {:?}", res);
-                    }
-                }
-                // println!("check_block_id: {:?}, check_block: {:?}", check_block_id, check_block);
-                if check_block_id == 10 {
-                    break
-                }
-                check_block_id += 1;
-
+            Some(res) => {
+                println!("res: {:?}", res);
             }
         }
-
+        // println!("check_block_id: {:?}, check_block: {:?}", check_block_id, check_block);
+        if check_block_id == 10 {
+            break
+        }
+        check_block_id += 1;
     }
-
 
     // println!("encoded: {:?}", encoded);
     // println!("decoder: {:?}", decoder);

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,6 +1,6 @@
 extern crate online_codes;
 
-use online_codes::encode::online_coder::OnlineCoder;
+use online_codes::encode::OnlineCoder;
 use rand::{thread_rng, Rng};
 use rand::distributions::Alphanumeric;
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,31 +1,54 @@
 extern crate online_codes;
 
 use online_codes::encode::OnlineCoder;
-use rand::{thread_rng, Rng};
-use rand::distributions::Alphanumeric;
+use online_codes::types::CheckBlockId;
+use proptest::prelude::*;
 
-#[test]
-fn basic_test() {
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10000))]
+    #[test]
+    fn test_identity(s in ".*") {
+        // Generate some data
+        // NOTE: We will not mangle it here, separate test for that
+        // We'll just see if we can encode <=> decode
+        let buf = s.clone().into_bytes();
+        let buf_len = buf.len();
+        let check_block_id = 0;
+        // Not ideal but okay for now to make things work
+        if buf_len > 4 {
+            let block_size = buf_len/4;
+            let num_blocks = buf_len / block_size;
+            // This _needs_ to be satisfied for it to work?
+            // I think we expect it to fail otherwise anyway?
+            if buf_len % block_size == 0 {
+                // The real test is here
+                if let Some(foo) = check_encode_decode(buf.clone(), num_blocks, block_size, check_block_id) {
+                    println!("buf: {:?}", buf);
+                    println!("foo: {:?}", foo);
+                    println!();
+                    assert_eq!(foo, buf);
+                }
+            }
+        }
+    }
+}
 
-    let buf_len = 128;
-    let block_size = 16;
-    let check_block_id = 0;
-
-    let s: String = thread_rng().sample_iter(&Alphanumeric).take(buf_len).collect();
-    let buf = s.clone().into_bytes();
-
+fn check_encode_decode(
+    buf: Vec<u8>,
+    num_blocks: usize,
+    block_size: usize,
+    check_block_id: CheckBlockId) -> Option<Vec<u8>> {
     let coder = OnlineCoder::new(block_size);
     let encoded = coder.encode(&buf, check_block_id);
-    let num_blocks = buf_len / block_size;
-    let mut decoder = coder.decode(num_blocks as usize, check_block_id);
+    let mut decoder = coder.decode(num_blocks, check_block_id);
 
     for (block_id, block) in encoded {
         match decoder.decode_block(block_id, &block) {
             None => continue,
             Some(res) => {
-                assert_eq!(buf, res);
-                break
+                return Some(res)
             }
         }
     }
+    None
 }


### PR DESCRIPTION
- Remove potentially unused lifetime variable
- Add proptest dev dep
- Basic identity test with 10000 default iterations, change by `export PROPTEST_CASES=<some int>`
- Return check_block_id from the iterator as well since it's needed to decode and simply enumerating is perhaps not guaranteed to work? I don't know, seemed like a good thing to do