### PR TITLE
Add format check to CI workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,3 +13,5 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Check Formatting
+      run: cargo fmt -- --check


### PR DESCRIPTION
This PR adds a workflow step which ensures all code is formatted. As it runs `cargo fmt` with `--check`, it does not format anything, but returns an error when a PR/push has unformatted code.

I purposely did not run `fmt` so we can ensure that CI does in fact fail.