### PR TITLE
Change API again and remove data len assertion

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -33,6 +33,7 @@ pub struct Decoder {
     pub adjacent_check_blocks: HashMap<BlockIndex, Vec<CheckBlockId>>,
     pub decode_stack: Vec<(CheckBlockId, Vec<u8>)>,
     pub aux_decode_stack: Vec<(BlockIndex, Vec<BlockIndex>)>,
+    pub pad: Option<i64>,
 }
 
 impl DecodeResult {
@@ -45,8 +46,13 @@ impl DecodeResult {
 }
 
 impl<'a> Decoder {
-    pub fn new(num_blocks: usize, block_size: usize, stream_id: StreamId) -> Decoder {
-        Self::with_parameters(num_blocks, block_size, stream_id, 0.01, 3)
+    pub fn new(
+        num_blocks: usize,
+        block_size: usize,
+        stream_id: StreamId,
+        pad: Option<i64>,
+    ) -> Decoder {
+        Self::with_parameters(num_blocks, block_size, stream_id, 0.01, 3, pad)
     }
 
     pub fn with_parameters(
@@ -55,6 +61,7 @@ impl<'a> Decoder {
         stream_id: StreamId,
         epsilon: f64,
         q: usize,
+        pad: Option<i64>,
     ) -> Decoder {
         let num_aux_blocks = num_aux_blocks(num_blocks, epsilon, q);
         let num_augmented_blocks = num_blocks + num_aux_blocks;
@@ -74,6 +81,7 @@ impl<'a> Decoder {
             adjacent_check_blocks: HashMap::new(),
             decode_stack: Vec::new(),
             aux_decode_stack: Vec::new(),
+            pad: pad,
         }
     }
 

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,11 +1,8 @@
 use crate::block_iter::BlockIter;
-use crate::decode::Decoder;
 use crate::types::StreamId;
 use crate::util::{
-    get_aux_block_adjacencies, make_degree_distribution, sample_with_exclusive_repeats,
-    seed_stream_rng, xor_block,
+    make_degree_distribution, sample_with_exclusive_repeats, seed_stream_rng, xor_block,
 };
-use std::collections::HashMap;
 
 #[derive(Clone, Debug)]
 pub struct OnlineCoder {
@@ -28,31 +25,8 @@ impl OnlineCoder {
     }
 
     pub fn encode(&self, data: Vec<u8>, stream_id: StreamId) -> BlockIter {
-        assert!(data.len() % self.block_size == 0);
         let aux_data = self.outer_encode(&data, stream_id);
         self.inner_encode(data, aux_data, stream_id)
-    }
-
-    fn decode(&self, num_blocks: usize, stream_id: StreamId) -> Decoder {
-        let num_aux_blocks = self.num_aux_blocks(num_blocks);
-        let num_augmented_blocks = num_blocks + num_aux_blocks;
-        let unused_aux_block_adjacencies =
-            get_aux_block_adjacencies(stream_id, num_blocks, num_aux_blocks, self.q);
-        Decoder {
-            num_blocks,
-            num_augmented_blocks: num_blocks + num_aux_blocks,
-            block_size: self.block_size,
-            unused_aux_block_adjacencies,
-            degree_distribution: make_degree_distribution(self.epsilon),
-            stream_id,
-            augmented_data: vec![0; num_augmented_blocks * self.block_size],
-            blocks_decoded: vec![false; num_augmented_blocks],
-            num_undecoded_data_blocks: num_blocks,
-            unused_check_blocks: HashMap::new(),
-            adjacent_check_blocks: HashMap::new(),
-            decode_stack: Vec::new(),
-            aux_decode_stack: Vec::new(),
-        }
     }
 
     fn num_aux_blocks(&self, num_blocks: usize) -> usize {

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -33,7 +33,7 @@ impl OnlineCoder {
         self.inner_encode(data, aux_data, stream_id)
     }
 
-    pub fn decode(&self, num_blocks: usize, stream_id: StreamId) -> Decoder {
+    fn decode(&self, num_blocks: usize, stream_id: StreamId) -> Decoder {
         let num_aux_blocks = self.num_aux_blocks(num_blocks);
         let num_augmented_blocks = num_blocks + num_aux_blocks;
         let unused_aux_block_adjacencies =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use block_iter::BlockIter;
 use decode::Decoder;
+use types::{CheckBlockId, StreamId};
 
 mod block_iter;
 pub mod decode;
@@ -20,16 +21,29 @@ pub struct Encoder {
     block_iter: BlockIter,
 }
 
-pub type Block = (u64, Vec<u8>);
+pub type Block = (CheckBlockId, Vec<u8>);
 
-pub fn new_encoder(buf: Vec<u8>, block_size: usize, stream_id: u64) -> Encoder {
+pub fn new_encoder(mut buf: Vec<u8>, block_size: usize, stream_id: StreamId) -> Encoder {
+    let len = buf.len();
+    let rem = len % block_size;
+    let pad: i64 = block_size as i64 - rem as i64;
+    buf.resize_with(len + pad.abs() as usize, || 0);
+
     let coder = encode::OnlineCoder::new(block_size);
     let block_iter = coder.encode(buf, stream_id);
     Encoder { block_iter }
 }
 
-pub fn new_decoder(buf_len: usize, block_size: usize, stream_id: u64) -> Decoder {
-    Decoder::new(buf_len / block_size, block_size, stream_id)
+pub fn new_decoder(buf_len: usize, block_size: usize, stream_id: StreamId) -> Decoder {
+    let len = buf_len;
+    let rem = len % block_size;
+    let pad: i64 = (block_size as i64 - rem as i64).abs();
+    Decoder::new(
+        (buf_len + pad as usize) / block_size,
+        block_size,
+        stream_id,
+        Some(pad),
+    )
 }
 
 pub fn next_block(encoder: &mut Encoder) -> Option<Block> {
@@ -37,5 +51,15 @@ pub fn next_block(encoder: &mut Encoder) -> Option<Block> {
 }
 
 pub fn decode_block(block: Block, decoder: &mut Decoder) -> Option<Vec<u8>> {
-    decoder.decode_block(block.0, &block.1)
+    match decoder.decode_block(block.0, &block.1) {
+        Some(mut block) => match decoder.pad {
+            Some(pad) => {
+                let len = block.len();
+                block.resize(len - pad as usize, 0);
+                Some(block)
+            }
+            None => Some(block),
+        },
+        None => None,
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,19 +22,14 @@ pub struct Encoder {
 
 pub type Block = (u64, Vec<u8>);
 
-// TODO: Should encode/1 return something else?
-pub fn encode(buf: Vec<u8>) -> (Encoder, Decoder) {
-    let buf_len = buf.len();
-    let block_size = buf_len / 4;
-    let stream_id = 0;
-
+pub fn new_encoder(buf: Vec<u8>, block_size: usize, stream_id: u64) -> Encoder {
     let coder = encode::OnlineCoder::new(block_size);
     let block_iter = coder.encode(buf, stream_id);
+    Encoder { block_iter }
+}
 
-    (
-        Encoder { block_iter },
-        coder.decode(buf_len / block_size, stream_id),
-    )
+pub fn new_decoder(buf_len: usize, block_size: usize, stream_id: u64) -> Decoder {
+    Decoder::new(buf_len / block_size, block_size, stream_id)
 }
 
 pub fn next_block(encoder: &mut Encoder) -> Option<Block> {

--- a/tests/basic.proptest-regressions
+++ b/tests/basic.proptest-regressions
@@ -6,3 +6,5 @@
 # everyone who runs the test benefits from these saved cases.
 cc d1db460bd8c4f898ccdd24f069136e875c86fb1d6630e1a09571bbf89d1f662b # shrinks to s = ""
 cc 0fd5fd9afb0824aa64dfdbabaacca4c4b39e2ab214fa492633b518123690f42a # shrinks to s = "AaA0 aA0 a\u{b}0a"
+cc 9a6750e79d587953c3b8d4f03e0ccfcee0d2a0b4c1856f4d2217868b65e1415e # shrinks to s = "𐀀0"
+cc f536ba08ff97bccb16a378bb1f2a7e513f0b2e4e5eef3203fddff29765391af2 # shrinks to s = "a\u{b}a¡0\u{b}𐀀\u{0}\u{b}00"

--- a/tests/basic.proptest-regressions
+++ b/tests/basic.proptest-regressions
@@ -8,3 +8,5 @@ cc d1db460bd8c4f898ccdd24f069136e875c86fb1d6630e1a09571bbf89d1f662b # shrinks to
 cc 0fd5fd9afb0824aa64dfdbabaacca4c4b39e2ab214fa492633b518123690f42a # shrinks to s = "AaA0 aA0 a\u{b}0a"
 cc 9a6750e79d587953c3b8d4f03e0ccfcee0d2a0b4c1856f4d2217868b65e1415e # shrinks to s = "𐀀0"
 cc f536ba08ff97bccb16a378bb1f2a7e513f0b2e4e5eef3203fddff29765391af2 # shrinks to s = "a\u{b}a¡0\u{b}𐀀\u{0}\u{b}00"
+cc 38f272ff73172770f308d0d9849ce0f9bdde24d905a2d9171f38087f84c1480e # shrinks to s = " ࠀ\u{0}ࠀ"
+cc f2ab4d931344118ebc5421760bc44bae71ec554cfa5051e064d89c50ef10e255 # shrinks to s = "¡𐀀Aࠀ𐀀\u{0}A"

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -60,8 +60,8 @@ fn check_encode_decode(buf: Vec<u8>) -> Option<Vec<u8>> {
     println!("buffer: {:?}", buf);
 
     let buf_len = buf.len();
-    let mut encoder = new_encoder(buf.clone(), buf_len / 4, 0);
-    let mut decoder = new_decoder(buf_len, buf_len / 4, 0);
+    let mut encoder = new_encoder(buf.clone(), 3, 0);
+    let mut decoder = new_decoder(buf_len, 3, 0);
 
     // TODO: Should we put a limit or loop infinitely?
     loop {
@@ -86,8 +86,8 @@ fn check_encode_decode_with_loss(buf: Vec<u8>, loss: f64) -> Option<(Vec<u8>, St
 
     println!("buffer: {:?}", buf);
     let buf_len = buf.len();
-    let mut encoder = new_encoder(buf.clone(), buf_len / 4, 0);
-    let mut decoder = new_decoder(buf_len, buf_len / 4, 0);
+    let mut encoder = new_encoder(buf.clone(), 4, 0);
+    let mut decoder = new_decoder(buf_len, 4, 0);
 
     // TODO: Should we put a limit or loop infinitely?
     loop {

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,7 +1,7 @@
 extern crate online_codes;
 
 use online_codes::types::StreamId;
-use online_codes::{decode_block, encode, next_block};
+use online_codes::{decode_block, new_decoder, new_encoder, next_block};
 use proptest::prelude::*;
 use rand::{thread_rng, Rng};
 
@@ -59,7 +59,9 @@ proptest! {
 fn check_encode_decode(buf: Vec<u8>) -> Option<Vec<u8>> {
     println!("buffer: {:?}", buf);
 
-    let (mut encoder, mut decoder) = encode(buf);
+    let buf_len = buf.len();
+    let mut encoder = new_encoder(buf.clone(), buf_len / 4, 0);
+    let mut decoder = new_decoder(buf_len, buf_len / 4, 0);
 
     // TODO: Should we put a limit or loop infinitely?
     loop {
@@ -83,7 +85,9 @@ fn check_encode_decode_with_loss(buf: Vec<u8>, loss: f64) -> Option<(Vec<u8>, St
     let mut loss_counter = 0;
 
     println!("buffer: {:?}", buf);
-    let (mut encoder, mut decoder) = encode(buf);
+    let buf_len = buf.len();
+    let mut encoder = new_encoder(buf.clone(), buf_len / 4, 0);
+    let mut decoder = new_decoder(buf_len, buf_len / 4, 0);
 
     // TODO: Should we put a limit or loop infinitely?
     loop {


### PR DESCRIPTION
This basically removes the assertion in `encode` function which enforced that the data length is evenly divisible by block size by padding the incoming data on the public API side and then removing the pad once the decode block is done.