### PR TITLE
Add criterion basic benchmarking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 **/*.rs.bk
 Cargo.lock
 *.log
+*.svg
+*.data
+*.old

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,11 @@ rand_xoshiro = "0.1"
 
 [dev-dependencies]
 proptest = "0.9.4"
+criterion = "0.3.5"
+
+[[bench]]
+name = "bench"
+harness = false
+
+[lib]
+bench = false

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,40 @@
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use criterion::Throughput;
+use criterion::{criterion_group, criterion_main};
+use online_codes::{decode_block, encode_data, next_block};
+
+fn check_encode_decode(buf: Vec<u8>) -> Option<Vec<u8>> {
+    let (mut encoder, mut decoder) = encode_data(buf);
+
+    loop {
+        match next_block(&mut encoder) {
+            Some(block) => match decode_block(block, &mut decoder) {
+                None => continue,
+                Some(res) => return Some(res),
+            },
+            None => continue,
+        }
+    }
+}
+
+fn identity_roundtrip(size: usize) -> Option<Vec<u8>> {
+    let random_bytes: Vec<u8> = (0..size).map(|_| rand::random::<u8>()).collect();
+    check_encode_decode(random_bytes)
+}
+
+fn kb_range(c: &mut Criterion) {
+    static KB: usize = 1024;
+
+    let mut group = c.benchmark_group("kb_range");
+    for size in [KB, 2 * KB, 4 * KB, 8 * KB, 16 * KB].iter() {
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+            b.iter(|| identity_roundtrip(size))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, kb_range);
+criterion_main!(benches);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,10 +2,12 @@ use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::Throughput;
 use criterion::{criterion_group, criterion_main};
-use online_codes::{decode_block, encode_data, next_block};
+use online_codes::{decode_block, new_decoder, new_encoder, next_block};
 
 fn check_encode_decode(buf: Vec<u8>) -> Option<Vec<u8>> {
-    let (mut encoder, mut decoder) = encode_data(buf);
+    let buf_len = buf.len();
+    let mut encoder = new_encoder(buf, 4, 0);
+    let mut decoder = new_decoder(buf_len, 4, 0);
 
     loop {
         match next_block(&mut encoder) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@ pub fn new_encoder(mut buf: Vec<u8>, block_size: usize, stream_id: StreamId) -> 
     let rem = len % block_size;
     let pad: i64 = block_size as i64 - rem as i64;
     buf.resize_with(len + pad.abs() as usize, || 0);
-
     let coder = encode::OnlineCoder::new(block_size);
     let block_iter = coder.encode(buf, stream_id);
     Encoder { block_iter }


### PR DESCRIPTION
Adds a `benches/bench.rs` to do basic enc-dec roundtrip benchmarking over 1-16 KB random data.